### PR TITLE
Feature/extract alto

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,11 @@ a part of the poppler-utils package.
 
 Used to extract text from image files (OCR). Requires [tesseract](https://tesseract-ocr.github.io/tessdoc/Command-Line-Usage.html).
 
+### xml
+
+Used to extract some xml from XML files. No requirements on most servers, else
+install the php extensions "xml" and "xmlreader".
+
 ## Disabling text extraction
 
 You can disable text extraction for individual extractors in the module config

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -23,11 +23,11 @@ return [
             'odt2txt' => ExtractText\Service\Extractor\Odt2txtFactory::class,
             'pdftotext' => ExtractText\Service\Extractor\PdftotextFactory::class,
             'tesseract' => ExtractText\Service\Extractor\TesseractFactory::class,
+            'xml' => ExtractText\Service\Extractor\XmlFactory::class,
         ],
         'invokables' => [
             'filegetcontents' => ExtractText\Extractor\Filegetcontents::class,
             'domdocument' => ExtractText\Extractor\Domdocument::class,
-            'xml' => ExtractText\Extractor\Xml::class,
         ],
         'aliases' => [
             'application/msword' => 'catdoc',

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -27,6 +27,7 @@ return [
         'invokables' => [
             'filegetcontents' => ExtractText\Extractor\Filegetcontents::class,
             'domdocument' => ExtractText\Extractor\Domdocument::class,
+            'xml' => ExtractText\Extractor\Xml::class,
         ],
         'aliases' => [
             'application/msword' => 'catdoc',
@@ -39,6 +40,7 @@ return [
             'text/xml' => 'domdocument',
             'application/xml' => 'domdocument',
             'application/tei+xml' => 'domdocument',
+            'application/alto+xml' => 'xml',
             'image/png' => 'tesseract',
             'image/jpeg' => 'tesseract',
             'image/tiff' => 'tesseract',

--- a/data/extractors/xml-alto.xslt
+++ b/data/extractors/xml-alto.xslt
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Extract text from xml alto, line by line.
+
+    @copyright Daniel Berthereau, 2022 for Numistral (Université de Strasbourg).
+    @license CeCILL 2.1 https://cecill.info/licences/Licence_CeCILL_V2.1-fr.txt
+-->
+
+<xsl:stylesheet version="1.0"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:alto2="http://www.loc.gov/standards/alto/ns-v2#"
+    xmlns:alto3="http://www.loc.gov/standards/alto/ns-v3#"
+    xmlns:alto4="http://www.loc.gov/standards/alto/ns-v4#"
+    >
+
+    <xsl:output method="text" encoding="UTF-8" />
+
+    <!-- End of line (the Linux one, because it's simpler and smarter). -->
+    <xsl:param name="end_of_line"><xsl:text>&#x0A;</xsl:text></xsl:param>
+
+    <xsl:template match="/">
+        <xsl:apply-templates select="//alto2:TextBlock | //alto3:TextBlock | //alto4:TextBlock"/>
+        <xsl:value-of select="$end_of_line"/>
+    </xsl:template>
+
+    <xsl:template match="alto2:TextBlock | alto3:TextBlock | alto4:TextBlock">
+        <xsl:apply-templates select="alto2:TextLine | alto3:TextLine | alto4:TextLine"/>
+        <xsl:value-of select="$end_of_line"/>
+    </xsl:template>
+
+    <xsl:template match="alto2:TextLine | alto3:TextLine | alto4:TextLine">
+        <xsl:apply-templates select="alto2:String | alto3:String | alto4:String"/>
+        <xsl:value-of select="$end_of_line"/>
+    </xsl:template>
+
+    <xsl:template match="alto2:String | alto3:String | alto4:String">
+        <xsl:value-of select="@CONTENT"/>
+        <xsl:if test="position() != last()">
+            <xsl:text> </xsl:text>
+        </xsl:if>
+    </xsl:template>
+
+</xsl:stylesheet>

--- a/data/media-types/media-type-identifiers.php
+++ b/data/media-types/media-type-identifiers.php
@@ -1,0 +1,82 @@
+<?php declare(strict_types=1);
+
+/**
+ * Map the output from xml checker and standard xml media types.
+ *
+ * Many Xml media types are not registered, so the unregistered tree (prefix "x")
+ * is used, except when the format is public, in which case the vendor tree is
+ * used (prefix "vnd").
+ *
+ * Some formats may need more check in code source.
+ *
+ * @var array
+ */
+return [
+    'application/xml'                                   => 'application/xml',
+    'text/xml'                                          => 'text/xml',
+
+    // Common namespaces (if not managed by fileinfo).
+
+    'http://www.w3.org/2000/svg'                        => 'image/svg+xml',
+    'application/vnd.oasis.opendocument.presentation'   => 'application/vnd.oasis.opendocument.presentation-flat-xml',
+    'application/vnd.oasis.opendocument.spreadsheet'    => 'application/vnd.oasis.opendocument.spreadsheet-flat-xml',
+    'application/vnd.oasis.opendocument.text'           => 'application/vnd.oasis.opendocument.text-flat-xml',
+    'http://www.w3.org/1999/xhtml'                      => 'application/xhtml+xml',
+    'http://www.w3.org/2005/Atom'                       => 'application/atom+xml',
+    'http://purl.org/rss/1.0/'                          => 'application/rss+xml',
+    // Common in library and culture world.
+    // 'http://bibnum.bnf.fr/ns/alto_prod'              => 'application/vnd.alto+xml', // Deprecated in 2017.
+    'http://bibnum.bnf.fr/ns/alto_prod'                 => 'application/alto+xml',
+    'http://bibnum.bnf.fr/ns/refNum'                    => 'application/vnd.bnf.refnum+xml',
+    'http://www.iccu.sbn.it/metaAG1.pdf'                => 'application/vnd.iccu.mag+xml',
+    // 'http://www.loc.gov/MARC21/slim'                 => 'application/vnd.marc21+xml', // Deprecated in 2011.
+    'http://www.loc.gov/MARC21/slim'                    => 'application/marcxml+xml',
+    // 'http://www.loc.gov/METS/'                       => 'application/vnd.mets+xml', // Deprecated in 2011.
+    'http://www.loc.gov/METS/'                          => 'application/mets+xml',
+    // 'http://www.loc.gov/mods/'                       => 'application/vnd.mods+xml', // Deprecated in 2011.
+    'http://www.loc.gov/mods/'                          => 'application/mods+xml',
+    // 'http://www.loc.gov/standards/alto/ns-v3#'       => 'application/vnd.alto+xml', // Deprecated in 2017.
+    'http://www.loc.gov/standards/alto/ns-v2#'          => 'application/alto+xml',
+    'http://www.loc.gov/standards/alto/ns-v3#'          => 'application/alto+xml',
+    'http://www.loc.gov/standards/alto/ns-v4#'          => 'application/alto+xml',
+    'http://www.music-encoding.org/ns/mei'              => 'application/vnd.mei+xml',
+    'http://www.music-encoding.org/schema/3.0.0/mei-all.rng' => 'application/vnd.mei+xml',
+    // See https://github.com/w3c/musicxml/blob/gh-pages/schema/musicxml.xsd
+    // But MusicXML can be zipped, and in that case has not the `+xml`, even if the content is the same.
+    'http://www.musicxml.org/xsd/MusicXML'              => 'application/vnd.recordare.musicxml+xml',
+    'http://www.openarchives.org/OAI/2.0/'              => 'application/vnd.openarchives.oai-pmh+xml',
+    'http://www.openarchives.org/OAI/2.0/static-repository' => 'application/vnd.openarchives.oai-pmh+xml',
+    // 'http://www.tei-c.org/ns/1.0'                    => 'application/vnd.tei+xml', // Deprecated in 2011.
+    'http://www.tei-c.org/ns/1.0'                       => 'application/tei+xml',
+    // 3D formats.
+    'http://www.collada.org/2005/11/COLLADASchema'      => 'model/vnd.collada+xml',
+    // Omeka should support itself.
+    'http://omeka.org/schemas/omeka-xml/v1'             => 'text/vnd.omeka+xml',
+    'http://omeka.org/schemas/omeka-xml/v2'             => 'text/vnd.omeka+xml',
+    'http://omeka.org/schemas/omeka-xml/v3'             => 'text/vnd.omeka+xml',
+    'http://omeka.org/schemas/omeka-xml/v4'             => 'text/vnd.omeka+xml',
+    'http://omeka.org/schemas/omeka-xml/v5'             => 'text/vnd.omeka+xml',
+
+    // Doctype and root elements in case there is no namespace.
+
+    // 'alto'                                           => 'application/vnd.alto+xml', // Deprecated in 2017.
+    'alto'                                              => 'application/alto+xml',
+    'ead'                                               => 'application/vnd.ead+xml',
+    'feed'                                              => 'application/atom+xml',
+    'html'                                              => 'text/html',
+    'mag'                                               => 'application/vnd.iccu.mag+xml',
+    'mei'                                               => 'application/vnd.mei+xml',
+    // 'mets'                                           => 'application/vnd.mets+xml', // Deprecated in 2011.
+    'mets'                                              => 'application/mets+xml',
+    // 'mods'                                           => 'application/vnd.mods+xml', // Deprecated in 2011.
+    'mods'                                              => 'application/mods+xml',
+    'pdf2xml'                                           => 'application/vnd.pdf2xml+xml',
+    'refNum'                                            => 'application/vnd.bnf.refnum+xml',
+    'rss'                                               => 'application/rss+xml',
+    'score-partwise'                                    => 'application/vnd.recordare.musicxml+xml',
+    'svg'                                               => 'image/svg+xml',
+    // 'TEI'                                            => 'application/vnd.tei+xml', // Deprecated in 2011.
+    'TEI'                                               => 'application/tei+xml',
+    // 'collection'                                     => 'application/marcxml+xml',
+    'xhtml'                                             => 'application/xhtml+xml',
+];

--- a/src/Extractor/Xml.php
+++ b/src/Extractor/Xml.php
@@ -3,27 +3,99 @@
 namespace ExtractText\Extractor;
 
 use DOMDocument;
+use Laminas\Log\Logger;
+use Omeka\Stdlib\Message;
 
 /**
- * Use php dom to extract text.
+ * Use php standard extensions Xml/XmlReader to extract text.
  *
  * @see https://www.php.net/manual/fr/book.dom.php
+ * @see https://www.php.net/manual/fr/book.xmlreader.php
  */
 class Xml implements ExtractorInterface
 {
+    /**
+     * @var \Laminas\Log\Logger
+     */
+    protected $logger;
+
+    public function __construct(Logger $logger)
+    {
+        $this->logger = $logger;
+    }
+
     public function isAvailable()
     {
-        return true;
+        // The extensions are enabled by default, but a check is done.
+        return extension_loaded('xml')
+            && extension_loaded('xmlreader');
     }
 
     public function extract($filePath, array $options = [])
     {
+        if (!$this->isAvailable()) {
+            return false;
+        }
+
+        $filePath = (string) $filePath;
+        if (!$this->isWellFormedXml($filePath)) {
+            return false;
+        }
+
         try {
             $domXml = new DOMDocument();
             $domXml = $this->load($filePath);
         } catch (\Exception $e) {
+            $message = new Message(
+                'The file "%s" is not a valid xml or its encoding is different from the one set in the xml root tag.', // @translate
+                basename($filePath)
+            );
+            $this->logger->err($message);
+            $this->logger->err($e);
             return false;
         }
+
         return $domXml->documentElement->textContent;
+    }
+
+    /**
+     * Check if an xml is well formed and log issues.
+     *
+     * @link https://stackoverflow.com/questions/13858074/validating-a-large-xml-file-400mb-in-php#answer-13858478
+     */
+    protected function isWellFormedXml(string $filePath): bool
+    {
+        // Use xmlReader.
+        $xml_parser = xml_parser_create();
+        if (!($fp = fopen($filePath, 'r'))) {
+            $message = new Message(
+                'File "%s" is not readable.', // @translate
+                basename($filePath)
+            );
+            $this->logger->err($message);
+            return false;
+        }
+
+        $errors = [];
+        while ($data = fread($fp, 4096)) {
+            if (!xml_parse($xml_parser, $data, feof($fp))) {
+                $errors[] = sprintf('Line #%s: %s',
+                    xml_get_current_line_number($xml_parser),
+                    xml_error_string(xml_get_error_code($xml_parser))
+                );
+            }
+        }
+        xml_parser_free($xml_parser);
+
+        if (count($errors)) {
+            $message = new Message(
+                'The file "%s" is not a valid xml or its encoding is different from the one set in the xml root tag: %s', // @translate
+                basename($filePath), array_unique($errors)
+            );
+            $this->logger->err($message);
+            return false;
+        }
+
+        return true;
     }
 }

--- a/src/Extractor/Xml.php
+++ b/src/Extractor/Xml.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types=1);
+
+namespace ExtractText\Extractor;
+
+use DOMDocument;
+
+/**
+ * Use php dom to extract text.
+ *
+ * @see https://www.php.net/manual/fr/book.dom.php
+ */
+class Xml implements ExtractorInterface
+{
+    public function isAvailable()
+    {
+        return true;
+    }
+
+    public function extract($filePath, array $options = [])
+    {
+        try {
+            $domXml = new DOMDocument();
+            $domXml = $this->load($filePath);
+        } catch (\Exception $e) {
+            return false;
+        }
+        return $domXml->documentElement->textContent;
+    }
+}

--- a/src/Extractor/Xml.php
+++ b/src/Extractor/Xml.php
@@ -87,7 +87,7 @@ class Xml implements ExtractorInterface
         if (count($errors)) {
             $message = new Message(
                 'The file "%s" is not a valid xml or its encoding is different from the one set in the xml root tag: %s', // @translate
-                basename($filePath), array_unique($errors)
+                basename($filePath), implode('; ', $errors)
             );
             $this->logger->err($message);
             return false;

--- a/src/Service/Extractor/XmlFactory.php
+++ b/src/Service/Extractor/XmlFactory.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types=1);
+
+namespace ExtractText\Service\Extractor;
+
+use ExtractText\Extractor\Xml;
+use Interop\Container\ContainerInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
+
+class XmlFactory implements FactoryInterface
+{
+    public function __invoke(ContainerInterface $services, $requestedName, array $options = null)
+    {
+        return new Xml(
+            $services->get('Omeka\Logger')
+        );
+    }
+}


### PR DESCRIPTION
When scanning documents, the format [alto](https://www.loc.gov/standards/alto) is often used to store ocr text, so it is useful to include it.