### PR TITLE
Add setting for default property visibility

### DIFF
--- a/src/Form/ConfigForm.php
+++ b/src/Form/ConfigForm.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace ExtractText\Form;
+
+use Laminas\Form\Form;
+
+class ConfigForm extends Form
+{
+    public function init()
+    {
+        $this->add([
+            'type' => \Laminas\Form\Element\Radio::class,
+            'name' => 'extracttext_default_is_public',
+            'options' => [
+                'label' => 'Default visibility', // @translate
+                'info' => 'When a resource has no "extracted text" properties, this setting determines the visibility of created properties. Otherwise, this is determined by the visibility of the last "extracted text" property.', // @translate
+                'value_options' => [
+                    '0' => 'Private', // @translate
+                    '1' => 'Public', // @translate
+                ],
+            ],
+        ]);
+    }
+}


### PR DESCRIPTION
This setting determines the visibility of new "extracted text" properties when a resource does not have existing "extracted text" properties.
It is configurable in the module's configuration form.

The "extracted text" property is often not directly displayed in site pages so it can be useful to make it private by default.

To test:

1. Install the module
2. Upload a .txt file to an item
3. Verify that the media "extracted text" property is public (the original behaviour is preserved)
4. Go to the module's config form
5. Change the default visibility to "Private"
6. Upload a .txt file to an item
7. Verify that the media "extracted text" property is private